### PR TITLE
Add visualize mode to help message

### DIFF
--- a/main.go
+++ b/main.go
@@ -191,7 +191,7 @@ func main() {
 	var input string
 	var filepath string
 	var reach bool
-	modeCommand := flag.String("m", "check", "stop compiler at certain milestones: ast, ir, smt, or check")
+	modeCommand := flag.String("m", "check", "stop compiler at certain milestones: ast, ir, smt, check, or visualize")
 	inputCommand := flag.String("i", "fspec", "format of the input file (default: fspec)")
 	fpCommand := flag.String("f", "", "path to file to compile")
 	reachCommand := flag.String("c", "false", "make sure the transitions to all defined states are specified in the model")


### PR DESCRIPTION
Reflect all valid modes in the usage message.

Before
```
  -m string
        stop compiler at certain milestones: ast, ir, smt, or check (default "check")
```
After
```
  -m string
        stop compiler at certain milestones: ast, ir, smt, check, or visualize (default "check")
```
