### PR TITLE
Exit with failure code with faults were found

### DIFF
--- a/main.go
+++ b/main.go
@@ -132,7 +132,7 @@ func run(filepath string, mode string, input string, reach bool) {
 		}
 
 		if !compiler.IsValid {
-			fmt.Println("Fault found nothing to run. Missing run block or start block.")
+			log.Fatal("Fault found nothing to run. Missing run block or start block.")
 			return
 		}
 
@@ -154,6 +154,7 @@ func run(filepath string, mode string, input string, reach bool) {
 			mc.LoadMeta(generator.GetForks())
 			fmt.Println("~~~~~~~~~~\n  Fault found the following scenario\n~~~~~~~~~~")
 			mc.Format(data)
+			os.Exit(1)
 		}
 	case "ll":
 		generator := smt2(d, 0, uncertains, unknowns, nil, nil)
@@ -171,6 +172,7 @@ func run(filepath string, mode string, input string, reach bool) {
 			mc.LoadMeta(generator.GetForks())
 			fmt.Println("~~~~~~~~~~\n  Fault found the following scenario\n~~~~~~~~~~")
 			mc.Format(data)
+			os.Exit(1)
 		}
 	case "smt2":
 		mc, data := probability(d, uncertains, unknowns, make(map[string][]*smtvar.VarChange))
@@ -182,6 +184,7 @@ func run(filepath string, mode string, input string, reach bool) {
 		if data != nil {
 			fmt.Println("~~~~~~~~~~\n  Fault found the following scenario\n~~~~~~~~~~")
 			mc.Format(data)
+			os.Exit(1)
 		}
 	}
 }


### PR DESCRIPTION
Fault is a CLI tool run by developers to check their work. Therefore it's reasonable to assume it will someday be used in CI builds. In that situation, a user would expect the default behavior to return non-zero exit code failing the pipeline.

If I've understood the various modes of execution correctly, this change will cause `fault` to return 1 when faults were found.

## Alternatives

Other conventions worth considering: allow an option to disable the meaningful return code (e.g. `--quiet`), or default to returning 0 and provide `--exit-code` option like `git-diff` does.

I opted for what seemed like the best default and avoiding customization unless it proved necessary, open to other ways.